### PR TITLE
CI: use ubuntu-latest runner

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The Pages deploy was stuck in `queued` because the workflow targets `runs-on: ubuntu-20.04`, whose GitHub-hosted runner image was retired in 2025 — no runner can satisfy that label, so jobs wait forever.

Switches to `ubuntu-latest`. Once merged, the push to `main` builds Hugo and deploys to `gh-pages`, bringing the site (and /fireplace/) live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)