### PR TITLE
CI: pin Hugo to 0.118.2 to fix the build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.118.2'
           extended: true
 
       - name: Build


### PR DESCRIPTION
The deploy now reaches Hugo but **fails at build**: the pinned 2022 `hugo-coder` theme calls `.Site.IsServer`, which current Hugo (v0.163, pulled by `hugo-version: 'latest'`) removed in favor of `hugo.IsServer`.

Pins `hugo-version` to **0.118.2** — a release that still has `.Site.IsServer` and predates the deprecated-config warnings — so the site builds clean and deploys. Unrelated to the Fireplace content (static, not templated).

Follow-up (separate work): modernize the `hugo-coder` fork to current Hugo and drop the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)